### PR TITLE
offset_in_kanji()のシグネチャ変更

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -3033,7 +3033,7 @@ E void FDECL(jputchar,(int));
 E void FDECL(jputs,(const char *));
 E int FDECL(is_kanji2, (const char *,int));
 E int FDECL(is_kanji1, (const char *,int));
-E int FDECL(offset_in_kanji, (const unsigned char *, int));
+E int FDECL(offset_in_kanji, (const char *, int));
 E int FDECL(isspace_8, (int));
 E void FDECL(split_japanese, (char *,char *,char *,int));
 E void FDECL(jrndm_replace, (char *));

--- a/japanese/jlib.c
+++ b/japanese/jlib.c
@@ -538,8 +538,8 @@ is_kanji1(s, pos)
  * 漢字の先頭位置まで何バイト戻る必要があるかを計算する
  */
 int
-offset_in_kanji(s, pos)
-     const unsigned char *s;
+offset_in_kanji(str, pos)
+     const char *str;
      int pos;
 {
     static int mask[7] = {
@@ -551,6 +551,7 @@ offset_in_kanji(s, pos)
         0xfc,
         0xfe,
     };
+    const unsigned char *s = (unsigned char *)str;
     if (output_kcode == UTF8) {
         int c = 1;
         int i;

--- a/win/tty/getline.c
+++ b/win/tty/getline.c
@@ -171,7 +171,7 @@ getlin_hook_proc hook;
 #if 1 /*JP*/
             {
                 int n;
-                n = offset_in_kanji((unsigned char *)tmp, bufp - tmp);
+                n = offset_in_kanji(tmp, bufp - tmp);
                 if (n > 0) {
                     /* Œã‚Å1ƒoƒCƒgˆø‚©‚ê‚é‚Ì‚Å‚»‚Ì•ª‚Í‚±‚±‚Å‚Íˆø‚©‚È‚¢ */
                     bufp = bufp - (n - 1);


### PR DESCRIPTION
呼び出し元はchar *ばかりなので関数内で変換することにする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 日本語テキスト処理における文字列型の一貫性を改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jnethack/jnethack-alpha/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->